### PR TITLE
Update link labels for all necessary items with platform designation.

### DIFF
--- a/packages/common/components/blocks/ad/emailx.marko
+++ b/packages/common/components/blocks/ad/emailx.marko
@@ -3,6 +3,8 @@ import defaultValue from "@parameter1/base-cms-marko-core/utils/default-value";
 
 $ const adUnit = getAsObject(input, "adUnit");
 $ const dpm = getAsObject(input, "dpm");
+$ const linkLabelProps = getAsObject(input, "linkLabelProps");
+$ const { adLocation, platformDesignator } = linkLabelProps;
 
 $ const useEmailxHref = defaultValue(input.useEmailxHref, false);
 $ const withLabel = defaultValue(input.withLabel, false);
@@ -37,7 +39,14 @@ $ const classNames = [`email-x-${alias}-${name}`, input.class];
             <tr>
               <td align="center" valign="top" class="mobile">
                 <marko-core-img ...input.image src=imageSrc attrs=imageAttrs class="img_resize1">
-                  <@link target="_blank" ...input.link href=href attrs={ linklabel: `ad|${input.adLocation}|d|${ad.advertiserName}|${ad.lineitemName}` } />
+                  <@link
+                    target="_blank"
+                    ...input.link
+                    href=href
+                    attrs={
+                      linklabel: `ad|${adLocation}|${platformDesignator}|${ad.advertiserName}|${ad.lineitemName}`
+                    }
+                  />
                 </marko-core-img>
                 <if(defaultValue(dpm.enabled, true))>
                   $ const position = dpm.position || 0;

--- a/packages/common/components/blocks/ad/promotion-advertisement.marko
+++ b/packages/common/components/blocks/ad/promotion-advertisement.marko
@@ -3,11 +3,14 @@ import { get, getAsObject } from "@parameter1/base-cms-object-path";
 $ const { req } = out.global;
 $ const nativeAdLayout = get(req, "query.native-ad-layout");
 $ const newsletter = getAsObject(input, "newsletter");
-$ const { sectionName, date, content } = input;
+$ const { sectionName, date, content, linkLabelProps } = input;
+$ const { adLocation, platformDesignator } = linkLabelProps;
 
 $ const url = get(content, "siteContext.path");
 $ const company = getAsObject(content, "company");
 $ const label = input.label || "Paid Advertisement";
+
+$ const linkLabel = `ad|${adLocation}|${platformDesignator}|${company.name}|${content.name}`;
 
 $ const imgStyles = {
   "font-size": "14px",
@@ -51,7 +54,7 @@ $ const imgLinkStyles = {
                     <table role="presentation" width="100%" border="0" cellpadding="0" cellspacing="0">
                       <tr>
                         <td align="left" valign="top" style="font-size: 24px;line-height: 28px;color: #202022;font-weight: 700;text-decoration: none;padding:0 24px 0 0;">
-                          <a href=url target="_blank" style="font-size: 24px;line-height: 28px;color: #202022;font-weight: 700;text-decoration: none;">${content.name}</a>
+                          <a href=url target="_blank" style="font-size: 24px;line-height: 28px;color: #202022;font-weight: 700;text-decoration: none;" linklabel=linkLabel>${content.name}</a>
                         </td>
                       </tr>
                       <common-table-spacer-element height="12" />
@@ -63,7 +66,7 @@ $ const imgLinkStyles = {
                             <table>
                               <tr>
                                 <td style="padding-right:24px">
-                                  <a href=url target="_blank" style="line-height: 90px;color: #257478;text-decoration: none;">
+                                  <a href=url target="_blank" style="line-height: 90px;color: #257478;text-decoration: none;" linklabel=linkLabel>
                                     Presented by
                                   </a>
                                 </td>
@@ -153,7 +156,7 @@ $ const imgLinkStyles = {
                       <common-table-spacer-element height="9" />
                       <tr>
                         <td align="left" valign="top" style="font-size: 17px;line-height: 22px;color: #3475b6;font-weight: 400;">
-                          <a href=url target="_blank" style="color: #68686a;text-decoration: none;">
+                          <a href=url target="_blank" style="color: #68686a;text-decoration: none;" linklabel=linkLabel>
                             <table>
                               <tr>
                                 <td style="-moz-border-radius:5px;-webkit-border-radius:5px;border-radius:5px; border: solid 2px #68686a;padding: 6px 12px;">
@@ -225,7 +228,7 @@ $ const imgLinkStyles = {
                       <common-table-spacer-element height="9" />
                       <tr>
                         <td align="left" valign="top" style="font-size: 17px;line-height: 22px;color: #3475b6;font-weight: 400;">
-                          <a href=url target="_blank" style="text-decoration: none;color: #3475b6;padding:0 24px 0 0;">${content.name}</a>
+                          <a href=url target="_blank" style="text-decoration: none;color: #3475b6;padding:0 24px 0 0;" linklabel=linkLabel>${content.name}</a>
                         </td>
                       </tr>
                     </table>
@@ -285,7 +288,7 @@ $ const imgLinkStyles = {
                       <common-table-spacer-element height="12" />
                       <tr>
                         <td align="left" valign="top" style="font-size: 24px;line-height: 28px;color: #202022;font-weight: 700;text-decoration: none;padding:0 24px 0 0;">
-                          <a href=url target="_blank" style="font-size: 24px;line-height: 28px;color: #202022;font-weight: 700;text-decoration: none;">${content.name}</a>
+                          <a href=url target="_blank" style="font-size: 24px;line-height: 28px;color: #202022;font-weight: 700;text-decoration: none;" linklabel=linkLabel>${content.name}</a>
                         </td>
                       </tr>
                       <common-table-spacer-element height="12" />

--- a/packages/common/components/blocks/ad/promotion-native.marko
+++ b/packages/common/components/blocks/ad/promotion-native.marko
@@ -1,8 +1,10 @@
 import { get, getAsObject } from "@parameter1/base-cms-object-path";
 
 $ const newsletter = getAsObject(input, "newsletter");
-$ const { sectionName, date, content } = input;
+$ const { sectionName, date, content, linkLabelProps } = input;
+$ const { adLocation, platformDesignator } = linkLabelProps;
+$ const linkLabel = `ad|${adLocation}|${platformDesignator}|${content.company.name}|${content.name}`;
 
 $ content.labels = ["Sponsored"];
 
-<common-content-list-item-block content=content withImage=false />
+<common-content-list-item-block content=content withImage=false link-label=linkLabel />

--- a/packages/common/components/blocks/ad/promotion-sponsored.marko
+++ b/packages/common/components/blocks/ad/promotion-sponsored.marko
@@ -1,10 +1,13 @@
 import { get, getAsObject } from "@parameter1/base-cms-object-path";
 
 $ const newsletter = getAsObject(input, "newsletter");
-$ const { sectionName, date, content } = input;
+$ const { sectionName, date, content, linkLabelProps } = input;
+$ const { adLocation, platformDesignator } = linkLabelProps;
 
 $ const url = get(content, "siteContext.path");
 $ const company = getAsObject(content, "company");
+
+$ const linkLabel = `ad|${adLocation}|${platformDesignator}|${company.name}|${content.name}`;
 
 $ const imgStyles = {
   "font-size": "14px",
@@ -76,7 +79,7 @@ $ const imgLinkStyles = {
               <common-table-spacer-element height="6" />
               <tr>
                 <td align="left" valign="top" style="font-size:16px;line-height:23px;color:#3475b6;font-weight:400;padding: 0 0 0 123px;" class="wdth">
-                  <a href=url target="_blank" style="text-decoration: none;color: #3475b6;">${content.name}</a>
+                  <a href=url target="_blank" style="text-decoration: none;color: #3475b6;" linklabel=linkLabel>${content.name}</a>
                 </td>
               </tr>
               <common-table-hr-element height="15" />

--- a/packages/common/components/blocks/ad/wrapper.marko
+++ b/packages/common/components/blocks/ad/wrapper.marko
@@ -27,6 +27,7 @@ $ const PromotionComponent = promotionComponents[defaultValue(input.promotionCom
         newsletter=newsletter
         section-name=sectionName
         content=convertAdToContent(data, { sectionName })
+        link-label-props=input.linkLabelProps
       />
     </if>
     <else-if(adUnit)>
@@ -35,6 +36,7 @@ $ const PromotionComponent = promotionComponents[defaultValue(input.promotionCom
         ad-unit=adUnit
         date=date
         dpm=input.dpm
+        link-label-props=input.linkLabelProps
       />
     </else-if>
   </native-x-fetch>
@@ -45,5 +47,6 @@ $ const PromotionComponent = promotionComponents[defaultValue(input.promotionCom
     ad-unit=adUnit
     date=date
     dpm=input.dpm
+    link-label-props=input.linkLabelProps
   />
 </else-if>

--- a/packages/common/components/blocks/content/list-item.marko
+++ b/packages/common/components/blocks/content/list-item.marko
@@ -38,7 +38,7 @@ $ const sponsoredTagStyle = {
   "color": "#a91b20",
 };
 
-$ const linkLabel = `story|${input.storyLocation}|${content.name}`;
+$ const linkLabel = input.storyLocation ? `story|${input.storyLocation}|${content.name}` : input.linkLabel;
 
 <tr>
   <td align="center" valign="top">

--- a/packages/common/components/layouts/standard.marko
+++ b/packages/common/components/layouts/standard.marko
@@ -3,6 +3,8 @@ import { parseBooleanHeader } from "@parameter1/base-cms-utils";
 import queryFragment from "@ascend-media/package-common/graphql/fragments/content-list";
 
 $ const { website, config, req } = out.global;
+$ const { 'sec-ch-ua-platform': operatingSystem } = get(req, "headers");
+$ const platformDesignator = operatingSystem.match(/iOS|Android/i) ? 'm' : 'd';
 $ const { newsletter, date } = input.data;
 
 $ const emailX = config.get("emailX");
@@ -25,7 +27,7 @@ $ const nativeX = config.getAsObject("nativeX");
           newsletter=newsletter
           ad-unit=emailX.getAdUnit({ name: 'ad-slot-1', alias: newsletter.alias })
           date=date
-          adLocation=1
+          link-label-props={ adLocation: 1, platformDesignator }
         />
 
         <!-- Content list block -->
@@ -44,7 +46,7 @@ $ const nativeX = config.getAsObject("nativeX");
           newsletter=newsletter
           promotion-component="advertisement-block"
           placement-id=get(nativeX, `placements.${newsletter.alias}.native-slot-1`)
-          adLocation=2
+          link-label-props={ adLocation: 2, platformDesignator }
         />
 
         <!-- Content list block -->
@@ -62,7 +64,7 @@ $ const nativeX = config.getAsObject("nativeX");
           newsletter=newsletter
           ad-unit=emailX.getAdUnit({ name: 'ad-slot-2', alias: newsletter.alias })
           date=date
-          adLocation=3
+          link-label-props={ adLocation: 3, platformDesignator }
         />
 
         <!-- Content list block -->
@@ -80,7 +82,7 @@ $ const nativeX = config.getAsObject("nativeX");
           newsletter=newsletter
           ad-unit=emailX.getAdUnit({ name: 'ad-slot-3', alias: newsletter.alias })
           date=date
-          adLocation=4
+          link-label-props={ adLocation: 4, platformDesignator }
         />
 
         <!-- Content list block -->
@@ -98,7 +100,7 @@ $ const nativeX = config.getAsObject("nativeX");
           newsletter=newsletter
           ad-unit=emailX.getAdUnit({ name: 'ad-slot-4', alias: newsletter.alias })
           date=date
-          adLocation=5
+          link-label-props={ adLocation: 5, platformDesignator }
         />
 
         <!-- Content list block -->
@@ -116,7 +118,7 @@ $ const nativeX = config.getAsObject("nativeX");
           newsletter=newsletter
           ad-unit=emailX.getAdUnit({ name: 'ad-slot-5', alias: newsletter.alias })
           date=date
-          adLocation=6
+          link-label-props={ adLocation: 6, platformDesignator }
         />
 
         <!-- Content list block -->
@@ -134,7 +136,7 @@ $ const nativeX = config.getAsObject("nativeX");
           newsletter=newsletter
           ad-unit=emailX.getAdUnit({ name: 'ad-slot-6', alias: newsletter.alias })
           date=date
-          adLocation=7
+          link-label-props={ adLocation: 7, platformDesignator }
         />
 
         <!-- Content list block -->
@@ -152,7 +154,7 @@ $ const nativeX = config.getAsObject("nativeX");
           newsletter=newsletter
           ad-unit=emailX.getAdUnit({ name: 'ad-slot-7', alias: newsletter.alias })
           date=date
-          adLocation=8
+          link-label-props={ adLocation: 8, platformDesignator }
         />
 
          <!-- Content list block -->

--- a/tenants/all/templates/aua-daily.marko
+++ b/tenants/all/templates/aua-daily.marko
@@ -3,6 +3,8 @@ import { parseBooleanHeader } from "@parameter1/base-cms-utils";
 import queryFragment from "@ascend-media/package-common/graphql/fragments/content-list";
 
 $ const { website, config, req } = out.global;
+$ const { 'sec-ch-ua-platform': operatingSystem } = get(req, "headers");
+$ const platformDesignator = operatingSystem.match(/iOS|Android/i) ? 'm' : 'd';
 $ const { newsletter, date } = data;
 
 $ const emailX = config.get("emailX");
@@ -25,7 +27,7 @@ $ const nativeX = config.getAsObject("nativeX");
           newsletter=newsletter
           ad-unit=emailX.getAdUnit({ name: 'ad-slot-1', alias: newsletter.alias })
           date=date
-          adLocation=1
+          link-label-props={ adLocation: 1, platformDesignator }
         />
 
         <!-- Content list block -->
@@ -44,7 +46,7 @@ $ const nativeX = config.getAsObject("nativeX");
           newsletter=newsletter
           promotion-component="advertisement-block"
           placement-id=get(nativeX, `placements.${newsletter.alias}.native-slot-1`)
-          adLocation=2
+          link-label-props={ adLocation: 2, platformDesignator }
         />
 
         <!-- Content list block -->
@@ -62,7 +64,7 @@ $ const nativeX = config.getAsObject("nativeX");
           newsletter=newsletter
           ad-unit=emailX.getAdUnit({ name: 'ad-slot-2', alias: newsletter.alias })
           date=date
-          adLocation=3
+          link-label-props={ adLocation: 3, platformDesignator }
         />
 
         <!-- Content list block -->
@@ -80,7 +82,7 @@ $ const nativeX = config.getAsObject("nativeX");
           newsletter=newsletter
           ad-unit=emailX.getAdUnit({ name: 'ad-slot-3', alias: newsletter.alias })
           date=date
-          adLocation=4
+          link-label-props={ adLocation: 4, platformDesignator }
         />
 
         <!-- Content list block -->
@@ -98,7 +100,7 @@ $ const nativeX = config.getAsObject("nativeX");
           newsletter=newsletter
           ad-unit=emailX.getAdUnit({ name: 'ad-slot-4', alias: newsletter.alias })
           date=date
-          adLocation=5
+          link-label-props={ adLocation: 5, platformDesignator }
         />
 
         <!-- Content list block -->
@@ -116,7 +118,7 @@ $ const nativeX = config.getAsObject("nativeX");
           newsletter=newsletter
           ad-unit=emailX.getAdUnit({ name: 'ad-slot-5', alias: newsletter.alias })
           date=date
-          adLocation=6
+          link-label-props={ adLocation: 6, platformDesignator }
         />
 
         <!-- Content list block -->
@@ -134,7 +136,7 @@ $ const nativeX = config.getAsObject("nativeX");
           newsletter=newsletter
           ad-unit=emailX.getAdUnit({ name: 'ad-slot-6', alias: newsletter.alias })
           date=date
-          adLocation=7
+          link-label-props={ adLocation: 7, platformDesignator }
         />
 
         <!-- Content list block -->
@@ -152,7 +154,7 @@ $ const nativeX = config.getAsObject("nativeX");
           newsletter=newsletter
           ad-unit=emailX.getAdUnit({ name: 'ad-slot-7', alias: newsletter.alias })
           date=date
-          adLocation=8
+          link-label-props={ adLocation: 8, platformDesignator }
         />
 
         <!-- Content list block -->
@@ -170,7 +172,7 @@ $ const nativeX = config.getAsObject("nativeX");
           newsletter=newsletter
           ad-unit=emailX.getAdUnit({ name: 'ad-slot-8', alias: newsletter.alias })
           date=date
-          adLocation=9
+          link-label-props={ adLocation: 9, platformDesignator }
         />
 
         <!-- Content list block -->
@@ -188,7 +190,7 @@ $ const nativeX = config.getAsObject("nativeX");
           newsletter=newsletter
           ad-unit=emailX.getAdUnit({ name: 'ad-slot-9', alias: newsletter.alias })
           date=date
-          adLocation=10
+          link-label-props={ adLocation: 10, platformDesignator }
         />
 
         <!-- Content list block -->
@@ -206,7 +208,7 @@ $ const nativeX = config.getAsObject("nativeX");
           newsletter=newsletter
           ad-unit=emailX.getAdUnit({ name: 'ad-slot-10', alias: newsletter.alias })
           date=date
-          adLocation=11
+          link-label-props={ adLocation: 11, platformDesignator }
         />
 
         <!-- Content list block -->


### PR DESCRIPTION
This will allow for all advertisements and promotions to have the appropriate labels including a platform designation (m=mobile, d=desktop) portion based off the value pass via the request header when the newsletter is loaded.