### PR TITLE
Correct story and ad numbering as appropriate.

### DIFF
--- a/packages/common/components/layouts/standard.marko
+++ b/packages/common/components/layouts/standard.marko
@@ -170,6 +170,37 @@ $ const nativeX = config.getAsObject("nativeX");
         <!-- Channels -->
         <common-channel-buttons-block newsletter=newsletter />
 
+        <script>
+          const allAnchors = document.getElementsByTagName('a');
+          const storyLabels = [];
+          const adLabels = [];
+          Object.keys(allAnchors).forEach((anchor) => {
+            const currentLinkLabel = allAnchors[anchor].getAttribute('linklabel');
+            if (currentLinkLabel) {
+              if (currentLinkLabel.match(/^story/)) {
+                storyLabels.push(currentLinkLabel);
+              } else if (currentLinkLabel.match(/^ad/)) {
+                adLabels.push(currentLinkLabel);
+              }
+            }
+          })
+          const labelMap = [];
+          adLabels.forEach((label, index) => {
+            labelMap.push({ was: adLabels[index], is: adLabels[index].replace(/[0-9]+/, index + 1) })
+          });
+          storyLabels.forEach((label, index) => {
+             labelMap.push({ was: storyLabels[index], is: storyLabels[index].replace(/[0-9]+/, index + 1) })
+          });
+          Object.keys(allAnchors).forEach((anchor) => {
+            const currentLinkLabel = allAnchors[anchor].getAttribute('linklabel');
+            if (currentLinkLabel) {
+              const foundLabel = labelMap.find((pair) => pair.was === currentLinkLabel);
+              if (foundLabel) {
+                allAnchors[anchor].setAttribute('linklabel', foundLabel.is);
+              }
+            }
+          });
+        </script>
       </@body>
     </common-body-wrapper-block>
   </@body>

--- a/tenants/all/templates/aua-daily.marko
+++ b/tenants/all/templates/aua-daily.marko
@@ -224,6 +224,38 @@ $ const nativeX = config.getAsObject("nativeX");
         <!-- Channels -->
         <common-channel-buttons-block newsletter=newsletter />
 
+
+        <script>
+          const allAnchors = document.getElementsByTagName('a');
+          const storyLabels = [];
+          const adLabels = [];
+          Object.keys(allAnchors).forEach((anchor) => {
+            const currentLinkLabel = allAnchors[anchor].getAttribute('linklabel');
+            if (currentLinkLabel) {
+              if (currentLinkLabel.match(/^story/)) {
+                storyLabels.push(currentLinkLabel);
+              } else if (currentLinkLabel.match(/^ad/)) {
+                adLabels.push(currentLinkLabel);
+              }
+            }
+          })
+          const labelMap = [];
+          adLabels.forEach((label, index) => {
+            labelMap.push({ was: adLabels[index], is: adLabels[index].replace(/[0-9]+/, index + 1) })
+          });
+          storyLabels.forEach((label, index) => {
+             labelMap.push({ was: storyLabels[index], is: storyLabels[index].replace(/[0-9]+/, index + 1) })
+          });
+          Object.keys(allAnchors).forEach((anchor) => {
+            const currentLinkLabel = allAnchors[anchor].getAttribute('linklabel');
+            if (currentLinkLabel) {
+              const foundLabel = labelMap.find((pair) => pair.was === currentLinkLabel);
+              if (foundLabel) {
+                allAnchors[anchor].setAttribute('linklabel', foundLabel.is);
+              }
+            }
+          });
+        </script>
       </@body>
     </common-body-wrapper-block>
   </@body>


### PR DESCRIPTION
This will correct the story and ad linklabels numbering relative to how many items were actually rendered. Ex: If Ad Slot 1 and 3 render but 2 doesn't the numbering will then be corrected to 1,2 instead of 1,3. (See Screenshot of AAD eNewsletter 1 August 6th 2021 below)
<img width="1694" alt="Screen Shot 2021-11-17 at 12 09 07 PM" src="https://user-images.githubusercontent.com/46794001/142258036-77163648-764c-4a3b-8a2d-394f4a662f89.png">


